### PR TITLE
feature(admin-loan-decision): Implement admin approve/reject loan endpoint

### DIFF
--- a/server/middleware/loanValidation.js
+++ b/server/middleware/loanValidation.js
@@ -1,4 +1,6 @@
-import { body, query, param, validationResult } from 'express-validator/check';
+import {
+  body, query, param, validationResult,
+} from 'express-validator/check';
 import { sanitizeBody } from 'express-validator/filter';
 
 const validateCreateLoan = [
@@ -71,6 +73,17 @@ const validateLoanId = [
     .withMessage('loan ID must be a positive integer from 1'),
 ];
 
+const validateLoanStatusUpdate = [
+  validateLoanId[0],
+  body('status')
+    .exists()
+    .withMessage('Status is required')
+    .isAlpha()
+    .withMessage('Status is invalid')
+    .matches(/^(approved|rejected)$/)
+    .withMessage('Status is invalid'),
+];
+
 const validationHandler = (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -88,6 +101,7 @@ const loanValidations = {
   validateCreateLoan,
   validateQueryParams,
   validateLoanId,
+  validateLoanStatusUpdate,
   validationHandler,
 };
 export default loanValidations;

--- a/server/routes/loan/loan.js
+++ b/server/routes/loan/loan.js
@@ -11,10 +11,16 @@ const {
   validateCreateLoan,
   validateQueryParams,
   validateLoanId,
+  validateLoanStatusUpdate,
   validationHandler,
 } = loanValidations;
 
-const { createLoan, getLoans, getSingleLoan } = LoanController;
+const {
+  createLoan,
+  getLoans,
+  getSingleLoan,
+  loanStatusUpdate,
+} = LoanController;
 
 // Router to create new loan
 loans.post('/', [verifyToken, userOnly, validateCreateLoan, validationHandler], createLoan);
@@ -24,5 +30,8 @@ loans.get('/', [verifyToken, adminOnly, validateQueryParams, validationHandler],
 
 // Router to get a specific loan
 loans.get('/:loanId', [verifyToken, adminOnly, validateLoanId, validationHandler], getSingleLoan);
+
+// Router to approve or reject a loan (update the status property)
+loans.patch('/:loanId', [verifyToken, adminOnly, validateLoanStatusUpdate, validationHandler], loanStatusUpdate);
 
 export default loans;

--- a/server/test/01-controllers/02-loanController.test.js
+++ b/server/test/01-controllers/02-loanController.test.js
@@ -252,4 +252,85 @@ describe('Loan', () => {
       expect(response.status).to.equal(401);
     });
   });
+
+  describe('Approve/Reject Loan Application', () => {
+    it('It should return a 404 error for a non-existing id', async () => {
+      const response = await chai
+        .request(app)
+        .patch('/api/v1/loans/13')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(mockData.statusUpdate.validStatus);
+
+      expect(response.status).to.equal(404);
+    });
+
+    it('Admin should be able to approve/reject loan application', async () => {
+      const response = await chai
+        .request(app)
+        .patch('/api/v1/loans/8')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(mockData.statusUpdate.validStatus);
+
+      expect(response.status).to.equal(200);
+    });
+
+    it('Admin cannot approve/reject loans for unverified users', async () => {
+      const response = await chai
+        .request(app)
+        .patch('/api/v1/loans/4')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(mockData.statusUpdate.validStatus);
+
+      expect(response.status).to.equal(403);
+    });
+
+    it('A user cannot approve/reject a loan', async () => {
+      const response = await chai
+        .request(app)
+        .patch('/api/v1/loans/2')
+        .set('Authorization', `Bearer ${userToken}`)
+        .send(mockData.statusUpdate.validStatus);
+
+      expect(response.status).to.equal(403);
+    });
+
+    it('It should return a 400 error for already approved loans', async () => {
+      const response = await chai
+        .request(app)
+        .patch('/api/v1/loans/6')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(mockData.statusUpdate.validStatus);
+
+      expect(response.status).to.equal(400);
+    });
+
+    it('It should return a 400 error for when an incorrect status is provided', async () => {
+      const response = await chai
+        .request(app)
+        .patch('/api/v1/loans/5')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(mockData.statusUpdate.invalidStatus);
+
+      expect(response.status).to.equal(400);
+    });
+
+    it('Should return an authorization error when an invalid token is passed', async () => {
+      const response = await chai
+        .request(app)
+        .patch('/api/v1/loans/2')
+        .set('Authorization', 'Bearer WrongToken')
+        .send(mockData.statusUpdate.validStatus);
+
+      expect(response.status).to.equal(401);
+    });
+
+    it('Should return an authentication error when authorization headers are not present', async () => {
+      const response = await chai
+        .request(app)
+        .patch('/api/v1/loans/2')
+        .send(mockData.statusUpdate.validStatus);
+
+      expect(response.status).to.equal(401);
+    });
+  });
 });

--- a/server/test/mock/index.js
+++ b/server/test/mock/index.js
@@ -234,10 +234,20 @@ const createLoan = {
   },
 };
 
+const statusUpdate = {
+  validStatus: {
+    status: 'approved',
+  },
+  invalidStatus: {
+    status: 'incorrect',
+  },
+};
+
 
 export default {
   login,
   signUp,
   resetPassword,
   createLoan,
+  statusUpdate,
 };


### PR DESCRIPTION
#### What does this PR do?
* Implements a `PATCH/api/v1/loans/<:loan_id>` endpoint for admin to approve or reject a loan application.

 #### Description of Task to be completed?
* Have the following endpoint working: `PATCH/api/v1/loans/<:loan_id>`
*req.param:* `{ loanId }`
*req.body:* `{ statusValue }`
* Authorize route to allow admin access only
* Write test for endpoint

#### How should this be manually tested?
* Clone the repo git clone `https://github.com/Bastieno/QuickCredit.git`
* Checkout to the branch `git checkout ft-admin-loan-decision-165739780`
* Install app dependencies `npm install`
* Run test `npm test`

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#165739780](https://www.pivotaltracker.com/n/projects/2328087)
